### PR TITLE
Cosmetic changes for blocks and further improvements

### DIFF
--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -161,12 +161,13 @@
 
 % Block settings
 % ==============
-\setbeamertemplate{blocks}[shadow=false]
+\setbeamertemplate{blocks}[shadow=false] 
+
 % Normal blocks
 \setbeamercolor{block title}{fg=bg_color,bg=block}
 \setbeamerfont{block title}{series=\bfseries}
 \setbeamercolor{block body}{parent=normal text,use=block title,bg=block title.bg!20!bg}
-\addtobeamertemplate{block begin}{}{
+\addtobeamertemplate{block begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=block}
   \setbeamercolor{itemize subitem}{fg=block}
   \setbeamercolor{itemize subsubitem}{fg=block}
@@ -176,10 +177,12 @@
   \setbeamercolor{enumerate subsubitem}{fg=block}
   \setbeamercolor{description item}{fg=block}
 }{}
+\addtobeamertemplate{block end}{}{\endminipage\par\endcenter}
+
 % Alert blocks
 \setbeamercolor{block title alerted}{fg=bg_color,bg=alert}
 \setbeamercolor{block body alerted}{parent=normal text,use=block title alerted,bg=block title alerted.bg!20!bg}
-\addtobeamertemplate{block alerted begin}{}{
+\addtobeamertemplate{block alerted begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=alert}
   \setbeamercolor{itemize subitem}{fg=alert}
   \setbeamercolor{itemize subsubitem}{fg=alert}
@@ -189,10 +192,12 @@
   \setbeamercolor{enumerate subsubitem}{fg=alert}
   \setbeamercolor{description item}{fg=alert}
 }{}
+\addtobeamertemplate{block alerted end}{}{\endminipage\par\endcenter}
+
 % Example blocks
 \setbeamercolor{block title example}{use=example text,fg=bg_color,bg=example}
 \setbeamercolor{block body example}{parent=normal text,use=block title example,bg=block title example.bg!20!bg}
-\addtobeamertemplate{block example begin}{}{
+\addtobeamertemplate{block example begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=example}
   \setbeamercolor{itemize subitem}{fg=example}
   \setbeamercolor{itemize subsubitem}{fg=example}
@@ -202,6 +207,7 @@
   \setbeamercolor{enumerate subsubitem}{fg=example}
   \setbeamercolor{description item}{fg=example}
 }{}
+\addtobeamertemplate{block example end}{}{\endminipage\par\endcenter}
 
 % Background
 % ==========

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -107,6 +107,7 @@
     \leaders\vrule width \textwidth\vskip0.4pt%
     \vskip0pt%
     \nointerlineskip
+    \vspace{-0.5cm}
 }
 
 % Table of content
@@ -167,7 +168,7 @@
 \setbeamercolor{block title}{fg=bg_color,bg=block}
 \setbeamerfont{block title}{series=\bfseries}
 \setbeamercolor{block body}{parent=normal text,use=block title,bg=block title.bg!20!bg}
-\addtobeamertemplate{block begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
+\addtobeamertemplate{block begin}{\vspace{-0.3cm}\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=block}
   \setbeamercolor{itemize subitem}{fg=block}
   \setbeamercolor{itemize subsubitem}{fg=block}
@@ -182,7 +183,7 @@
 % Alert blocks
 \setbeamercolor{block title alerted}{fg=bg_color,bg=alert}
 \setbeamercolor{block body alerted}{parent=normal text,use=block title alerted,bg=block title alerted.bg!20!bg}
-\addtobeamertemplate{block alerted begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
+\addtobeamertemplate{block alerted begin}{\vspace{-0.3cm}\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=alert}
   \setbeamercolor{itemize subitem}{fg=alert}
   \setbeamercolor{itemize subsubitem}{fg=alert}
@@ -197,7 +198,7 @@
 % Example blocks
 \setbeamercolor{block title example}{use=example text,fg=bg_color,bg=example}
 \setbeamercolor{block body example}{parent=normal text,use=block title example,bg=block title example.bg!20!bg}
-\addtobeamertemplate{block example begin}{\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
+\addtobeamertemplate{block example begin}{\vspace{-0.3cm}\setlength{\textwidth}{0.98\textwidth}\center\minipage{\textwidth}}{
   \setbeamercolor{itemize item}{fg=example}
   \setbeamercolor{itemize subitem}{fg=example}
   \setbeamercolor{itemize subsubitem}{fg=example}

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -243,7 +243,7 @@
       \hspace{0.055\paperwidth}}
     \vfil
     \hbox to \paperwidth{
-      \hspace{0.048\paperwidth}
+      \hspace{0.053\paperwidth}
       \includegraphics[width=.12\paperwidth]{\ETHLogo}
       \hspace{0.03\textwidth}
       \tiny Center for Climate Systems Modeling C2SM

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -1,4 +1,4 @@
-\NeedsTeXFormat{LaTeX2e}[1994/06/01]
+ \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{beamertools}
 [2022/11/01 v0.01 LaTeX package for various beamer convenience functions]
 

--- a/main.tex
+++ b/main.tex
@@ -13,6 +13,13 @@
 \usepackage{fontspec}
 \usepackage[sfdefault,light]{roboto}
 \usepackage{beamertools}
+\usepackage{pdfpages}
+\usepackage{booktabs}
+\usepackage{caption}
+\usepackage{tabularx,ragged2e}
+\usepackage{xcolor}
+\usepackage{array}
+\usepackage{appendixnumberbeamer}
 
 % Set hyperlink color
 % (url color defined in beamerthemeC2SM.sty, chnages with dark/light mode)

--- a/main.tex
+++ b/main.tex
@@ -6,6 +6,7 @@
 \usepackage{rotating}
 \usepackage[normalem]{ulem}
 \usepackage{amsmath}
+\usepackage[customcolors]{hf-tikz}
 \usepackage{amssymb}
 \usepackage{capt-of}
 \usepackage{hyperref}
@@ -14,13 +15,25 @@
 \usepackage[sfdefault,light]{roboto}
 \usepackage{beamertools}
 \usepackage{tango}
+\usepackage{setspace}
 \usepackage{pdfpages}
 \usepackage{booktabs}
 \usepackage{caption}
 \usepackage{tabularx,ragged2e}
 \usepackage{xcolor}
+\usepackage{pifont}
 \usepackage{array}
+\usepackage{import}
+\usepackage[justification=centering]{caption}
 \usepackage{appendixnumberbeamer}
+\usepackage{fontawesome}
+\usepackage[skins]{tcolorbox}
+\usepackage[version=4]{mhchem}
+\usepackage{tikz}
+\usetikzlibrary{math}
+\usetikzlibrary{calc}
+\usetikzlibrary{positioning}
+\usetikzlibrary{fadings}
 
 % Set hyperlink color
 % (url color defined in beamerthemeC2SM.sty, chnages with dark/light mode)

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,3 @@
-% Created 2022-11-04 Fri 11:35
-% Intended LaTeX compiler: pdflatex
 \documentclass[presentation, aspectratio=169]{beamer}
 \usepackage[T1]{fontenc}
 \usepackage{graphicx}

--- a/main.tex
+++ b/main.tex
@@ -13,6 +13,7 @@
 \usepackage{fontspec}
 \usepackage[sfdefault,light]{roboto}
 \usepackage{beamertools}
+\usepackage{tango}
 \usepackage{pdfpages}
 \usepackage{booktabs}
 \usepackage{caption}


### PR DESCRIPTION
Blocks were too large horizontally compared to other elements. Additionally there was too much vertical space for blocks.

- [x] Resize blocks to match other elements (title, footer, text)
- [x] Adjust vertical alignment for blocks]
- [x] Rename `template.tex` to `main.tex`
- [x] Add more packages that have been used in previous presentations, especially `tango` 
- [x] Adjusting alignment for ETH logo in footer 
