### PR TITLE
Improve Beamer Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# LaTeX generated files
+*.aux
+*.log
+*.out
+*.toc
+*.lof
+*.lot
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+*.synctex(busy)
+*.bbl
+*.blg
+*.bcf
+*.run.xml
+*.nav
+*.snm
+*.vrb
+*.idx
+*.ind
+*.ilg
+*.glo
+*.gls
+*.glg
+*.xdv
+_minted-*/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.aux
 *.log
 *.out
+*.pdf
 *.toc
 *.lof
 *.lot

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -327,5 +327,9 @@
 
 % Apply theme URL color to hyperlinks
 \AtBeginDocument{%
-  \hypersetup{colorlinks=true, linkcolor=url, urlcolor=url}%
+  \if@doDarkMode
+    \hypersetup{urlcolor=[HTML]{6AB0F5}, linkcolor=[HTML]{6AB0F5}}%
+  \else
+    \hypersetup{urlcolor=[HTML]{1558A6}, linkcolor=[HTML]{1558A6}}%
+  \fi
 }

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -88,7 +88,11 @@
 \fi
 
 \colorlet{block}{struct}
-\colorlet{url}{struct}
+\if@doDarkMode
+    \definecolor{url}{HTML}{6AB0F5}  % vivid blue for dark background
+\else
+    \definecolor{url}{HTML}{1558A6}  % dark blue for light background
+\fi
 \setbeamercolor{structure}{fg=struct, bg=bg_color}
 \setbeamercolor{title}{fg=bg_color, bg=struct}
 
@@ -262,7 +266,14 @@
 \setbeamerfont{part title}{size=\Large, series=\bfseries}
 \setbeamerfont{subtitle}{size=\large, series=\bfseries}
 \setbeamerfont{author}{size=\normalsize, series=\mdseries}
-\setbeamerfont{date}{size=\normalsize, series=\mdseries}
+\setbeamerfont{date}{size=\footnotesize, series=\mdseries}
+
+% Default definitions for optional title page fields
+\def\location{}
+\def\affiliations{}
+\def\event{}
+% Author affiliation footnote command
+\newcommand{\affil}[2]{\textsuperscript{#1}\,\textit{#2}}
 
 % Set title page template
 \setbeamertemplate{title page}{
@@ -281,9 +292,26 @@
         {\usebeamerfont{subtitle}\usebeamercolor[fg]{subtitle}\insertsubtitle\par}%
         \fi%
         \vskip1em\par
-        \usebeamerfont{author}\insertauthor
+        \usebeamerfont{author}\textsc{\insertauthor}%
+        \ifx\affiliations\@empty%
+        \else%
+        \vskip0.5em\par%
+        {\usebeamerfont{date}\affiliations}%
+        \fi%
         \vskip1em\par
-        \usebeamerfont{date}\insertdate
+        {\usebeamerfont{date}\makebox[1.2em][c]{\faCalendar[regular]}~\insertdate}%
+        \ifx\event\@empty%
+        \else%
+        \vskip0.3em\par%
+        {\usebeamerfont{date}\makebox[1.2em][c]{\faUsers}~\event%
+        \ifx\location\@empty\else\hspace{1em}\makebox[1.2em][c]{\faMapMarker*}~\location\fi}%
+        \fi%
+        \ifx\event\@empty%
+        \ifx\location\@empty%
+        \else%
+        \vskip0.3em\par%
+        {\usebeamerfont{date}\makebox[1.2em][c]{\faMapMarker*}~\location}%
+        \fi\fi
       \end{beamercolorbox}
       \hfil}
     \vskip0.5em

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -324,3 +324,8 @@
       {\usebeamerfont{part title}\usebeamercolor{part title}\insertpart\par}%
   \end{frame}
 }
+
+% Apply theme URL color to hyperlinks
+\AtBeginDocument{%
+  \hypersetup{colorlinks=true, linkcolor=url, urlcolor=url}%
+}

--- a/beamerthemeC2SM.sty
+++ b/beamerthemeC2SM.sty
@@ -272,8 +272,36 @@
 \def\location{}
 \def\affiliations{}
 \def\event{}
+
 % Author affiliation footnote command
 \newcommand{\affil}[2]{\textsuperscript{#1}\,\textit{#2}}
+
+% Internal empty sentinel
+\def\authors{}
+\def\authorplain{}
+
+\def\addauthor#1#2{%
+  \ifx\authors\empty
+    \ifx\relax#2\relax % if #2 is empty
+      \def\authors{#1}%
+    \else
+      \def\authors{#1\textsuperscript{#2}}%
+    \fi
+    \def\authorplain{#1}%
+  \else
+    \ifx\relax#2\relax
+      \g@addto@macro\authors{, #1}%
+    \else
+      \g@addto@macro\authors{, #1\textsuperscript{#2}}%
+    \fi
+    \g@addto@macro\authorplain{, #1}%
+  \fi
+}
+
+% \addaffil{number}{Institution}  — appends, doesn't overwrite
+\newcommand{\addaffil}[2]{%
+  \g@addto@macro\affiliations{\affil{#1}{#2}\quad}%
+}
 
 % Set title page template
 \setbeamertemplate{title page}{
@@ -292,7 +320,7 @@
         {\usebeamerfont{subtitle}\usebeamercolor[fg]{subtitle}\insertsubtitle\par}%
         \fi%
         \vskip1em\par
-        \usebeamerfont{author}\textsc{\insertauthor}%
+          \usebeamerfont{author}\textsc{\authors}%
         \ifx\affiliations\@empty%
         \else%
         \vskip0.5em\par%

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -127,7 +127,13 @@
     \setbeamercolor{enumerate item}{fg=bgcol}
     \setbeamercolor{enumerate subitem}{fg=bgcol}
     \setbeamercolor{enumerate subsubitem}{fg=bgcol}
-    \begin{tcolorbox}[colback=bgcol!15!bg, colframe=bgcol, colupper=fg, boxrule=0pt, frame empty, arc=0pt, outer arc=0pt, #1]}
+    \def\prioritylabel{#2}%
+    \begin{tcolorbox}[enhanced, colback=bgcol!15!bg, colframe=bgcol, colupper=fg, boxrule=0pt,
+        arc=0pt, outer arc=0pt,
+        overlay={\node[circle, fill=bgcol, text=white, font=\bfseries\small,
+                       inner sep=2pt, minimum size=1.6em]
+                       at ([xshift=1.3em]frame.west) {\prioritylabel};},
+        left=2.2em, #1]}
     {\end{tcolorbox} \endgroup}
 
 \newcommand<>{\smileyframe}[2][]{

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -4,6 +4,7 @@
 
 \RequirePackage{xkeyval}
 \RequirePackage[export]{adjustbox} % graphicx is also included
+\RequirePackage{colortbl}          % \rowcolor, \rowcolors, \columncolor
 \RequirePackage{tikz}
 \usetikzlibrary{shapes.arrows}
 \usetikzlibrary{calc,math,positioning,fadings}
@@ -179,4 +180,29 @@
 % Compact small-dot ToC subsection template
 \defbeamertemplate{subsection in toc}{smalldot}{%
   \leavevmode\leftskip=1.7em\hspace{0.3em}\inserttocsubsection\par%
+}
+
+%% Tables
+\newcommand{\textrow}[2]{\textcolor{#1}{#2}}
+
+% Define colors
+\definecolor{BlueHeader}{HTML}{336699}  % darker header so white text is visible
+\definecolor{BlueRowA}{HTML}{43525E}
+\definecolor{BlueRowB}{HTML}{4B5C69}
+
+% New environment: bluetable
+\newenvironment{bluetable}[1] % #1 = column specification
+{
+    \renewcommand{\arraystretch}{1.25} % increase row height (1.0 = default)
+    % Apply alternating row colors to body
+    \rowcolors{2}{BlueRowA}{BlueRowB} 
+    \begingroup
+
+    \begin{tabular}{#1} 
+    \rowcolor{BlueHeader} % header background
+}
+{
+    \end{tabular} 
+    \endgroup
+    \rowcolors{2}{}{} % reset row colors 
 }

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -6,7 +6,9 @@
 \RequirePackage[export]{adjustbox} % graphicx is also included
 \RequirePackage{tikz}
 \usetikzlibrary{shapes.arrows}
+\usetikzlibrary{calc,math,positioning,fadings}
 \RequirePackage[skins]{tcolorbox}
+\RequirePackage{fontawesome5}
 
 % Draw nice "imply"-like arrows
 \newcommand{\beamerarrow}{\tikz{\node[single arrow,scale=0.3,
@@ -155,3 +157,26 @@
 \newenvironment{codeblock}
 {\colorlet{framecol}{normal text.fg}\begin{tcolorbox}[standard jigsaw, colback=framecol, colframe=framecol, opacityback=0.07, boxsep=0.5em, left=0pt, right=0pt, bottom=0pt, top=0pt, boxrule=0.5pt]\color{framecol}\scriptsize\begin{semiverbatim}}
 {\end{semiverbatim}\end{tcolorbox}}
+
+% Helper for icon tables: icon + command name
+\newcommand{\farow}[2]{\makebox[1.4em]{\large#1}\,{\small\inlinecode{#2}}}
+
+% Helper for emoji tables: emoji + CLDR name as inlinecode (requires emoji package)
+\newcommand{\emorow}[1]{\makebox[1.6em]{\emoji{#1}}\,{\small\inlinecode{#1}}}
+
+% Compact circular ToC section number template
+\defbeamertemplate{section in toc}{smallcircle}{%
+  \leavevmode%
+  \usebeamerfont*{section number projected}%
+  \usebeamercolor{section number projected}%
+  \tikz[baseline=(char.base), inner sep=0pt, outer sep=0pt]{%
+    \node[circle, fill=bg, text=fg, inner sep=1.5pt,%
+          font=\footnotesize\bfseries, minimum size=1.4em] (char) {\inserttocsectionnumber};%
+  }\hspace{0.3em}%
+  \inserttocsection\par%
+}
+
+% Compact small-dot ToC subsection template
+\defbeamertemplate{subsection in toc}{smalldot}{%
+  \leavevmode\leftskip=1.7em\hspace{0.3em}\inserttocsubsection\par%
+}

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -63,7 +63,6 @@
 % Make colorboxes with custom background and itemize colors
 \newenvironment<>{customcolbox}[1]{
   \begingroup
-  \setbeamercolor{boxcolor}{fg=normal text.fg,bg=#1!20!bg}
   \setbeamercolor{itemize item}{fg=#1}
   \setbeamercolor{itemize subitem}{fg=#1}
   \setbeamercolor{itemize subsubitem}{fg=#1}
@@ -72,8 +71,10 @@
   \setbeamercolor{enumerate subitem}{fg=#1}
   \setbeamercolor{enumerate subsubitem}{fg=#1}
   \setbeamercolor{description item}{fg=#1}
-  \begin{beamercolorbox}{boxcolor}}
-  {\end{beamercolorbox} \endgroup}
+  \begin{tcolorbox}[colback=#1!20!bg, colframe=#1!20!bg, colupper=fg,
+      boxrule=0pt, arc=0pt, outer arc=0pt,
+      left=0.5em, right=0.5em, top=0.3em, bottom=0.3em]}
+  {\end{tcolorbox} \endgroup}
 
 % simple tcolorbox choosing one color, itmize and bg colors are derived from it
 \newenvironment<>{framebox}[2][]{

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -33,15 +33,17 @@
   \endgroup
 }
 
-% Frame watermark: diagonal semi-transparent text overlay
+% Frame watermark: footer badge
 % Usage: \watermark[color]{text}   (default color: alert)
 % Place anywhere inside a frame to mark a slide as work-in-progress.
 \newcommand{\watermark}[2][alert]{%
   \begin{tikzpicture}[remember picture, overlay]
-    \node[rotate=45, opacity=0.20,
-          font={\fontsize{72}{72}\selectfont\bfseries\sffamily},
-          text=#1, anchor=center]
-      at (current page.center) {#2};
+    \node[anchor=east,
+          font={\small\bfseries\sffamily},
+          text=#1, draw=#1,
+          rounded corners=2pt,
+          inner sep=3pt]
+      at ([xshift=-0.24\paperwidth, yshift= 0.04\paperheight]current page.south east) {#2};
   \end{tikzpicture}%
 }
 

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -85,7 +85,7 @@
   \setbeamercolor{enumerate item}{fg=#2}
   \setbeamercolor{enumerate subitem}{fg=#2}
   \setbeamercolor{enumerate subsubitem}{fg=#2}
-  \begin{tcolorbox}[colback=#2!15!bg, colframe=#2, #1]}
+  \begin{tcolorbox}[colback=#2!15!bg, colframe=#2, colupper=fg, coltitle=fg, colbacktitle=#2!40!bg, #1]}
   {\end{tcolorbox} \endgroup}
 
 % Some handy new environments

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -1,4 +1,4 @@
- \NeedsTeXFormat{LaTeX2e}[1994/06/01]
+\NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{beamertools}
 [2022/11/01 v0.01 LaTeX package for various beamer convenience functions]
 
@@ -219,4 +219,31 @@
     \end{tabular} 
     \endgroup
     \rowcolors{2}{}{} % reset row colors 
+}
+
+% Author/affiliation collection macros
+
+
+\newcommand{\addauthor}[3]{%
+  % Add author name with superscript
+  \ifx\authornames\@empty
+    \gdef\authornames{#1\textsuperscript{#2}}%
+  \else
+    \gdef\authornames{\authornames, #1\textsuperscript{#2}}%
+  \fi
+  % Add affiliation if not already present
+  \expandafter\ifx\csname affil@#2\endcsname\relax
+    \expandafter\gdef\csname affil@#2\endcsname{#3}%
+    \ifx\affillist\@empty
+      \gdef\affillist{\textsuperscript{#2}\,\textit{#3}}%
+    \else
+      \gdef\affillist{\affillist\\\textsuperscript{#2}\,\textit{#3}}%
+    \fi
+  \fi
+}
+
+% Helper to reset authors/affiliations (call before \addauthor)
+\newcommand{\clearauthors}{%
+  \gdef\authornames{}%
+  \gdef\affillist{}%
 }

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -33,6 +33,18 @@
   \endgroup
 }
 
+% Frame watermark: diagonal semi-transparent text overlay
+% Usage: \watermark[color]{text}   (default color: alert)
+% Place anywhere inside a frame to mark a slide as work-in-progress.
+\newcommand{\watermark}[2][alert]{%
+  \begin{tikzpicture}[remember picture, overlay]
+    \node[rotate=45, opacity=0.20,
+          font={\fontsize{72}{72}\selectfont\bfseries\sffamily},
+          text=#1, anchor=center]
+      at (current page.center) {#2};
+  \end{tikzpicture}%
+}
+
 % Add a background figure relative to the center of the page
 % put any options to \node in the #2 argument like xshift, yshift or opacity
 % put any options to \includegraphics in the #3 argument

--- a/beamertools.sty
+++ b/beamertools.sty
@@ -98,7 +98,7 @@
     \setbeamercolor{enumerate item}{fg=Plum3}
     \setbeamercolor{enumerate subitem}{fg=Plum3}
     \setbeamercolor{enumerate subsubitem}{fg=Plum3}
-    \begin{tcolorbox}[colback=Plum3!15!bg, boxrule=0.5pt, arc=0pt, outer arc=0pt, left=0pt, right=1pt, top=1pt, bottom=1pt, #1]}
+    \begin{tcolorbox}[colback=Plum3!15!bg, colframe=Plum3, colupper=fg, boxrule=0.5pt, arc=0pt, outer arc=0pt, left=0pt, right=1pt, top=1pt, bottom=1pt, #1]}
     {\end{tcolorbox} \endgroup}
 
 \newenvironment<>{taskproposal}[1][]{
@@ -110,14 +110,14 @@
     \setbeamercolor{enumerate item}{fg=SkyBlue3}
     \setbeamercolor{enumerate subitem}{fg=SkyBlue3}
     \setbeamercolor{enumerate subsubitem}{fg=SkyBlue3}
-    \begin{tcolorbox}[colback=SkyBlue3!15!bg, colframe=SkyBlue3, #1]}
+    \begin{tcolorbox}[colback=SkyBlue3!15!bg, colframe=SkyBlue3, colupper=fg, #1]}
     {\end{tcolorbox} \endgroup}
 
 \newenvironment<>{priority}[2][]{
     \ifthenelse{\equal{#2}{A}}{\colorlet{bgcol}{Chameleon3}}{
         \ifthenelse{\equal{#2}{B}}{\colorlet{bgcol}{Orange3}}{
             \ifthenelse{\equal{#2}{C}}{\colorlet{bgcol}{ScarletRed3}}{
-                \ifthenelse{\equal{#2}{D}}{\colorlet{bgcol}{Aluminium6}}{
+                \ifthenelse{\equal{#2}{D}}{\colorlet{bgcol}{Aluminium3}}{
                     \colorlet{bgcol}{C2SM_petrol_blue}}}}}
     \begingroup
     \setbeamercolor{itemize item}{fg=bgcol}
@@ -127,7 +127,7 @@
     \setbeamercolor{enumerate item}{fg=bgcol}
     \setbeamercolor{enumerate subitem}{fg=bgcol}
     \setbeamercolor{enumerate subsubitem}{fg=bgcol}
-    \begin{tcolorbox}[colback=bgcol!15!bg, boxrule=0pt, frame empty, arc=0pt, outer arc=0pt, #1]}
+    \begin{tcolorbox}[colback=bgcol!15!bg, colframe=bgcol, colupper=fg, boxrule=0pt, frame empty, arc=0pt, outer arc=0pt, #1]}
     {\end{tcolorbox} \endgroup}
 
 \newcommand<>{\smileyframe}[2][]{

--- a/main.tex
+++ b/main.tex
@@ -686,10 +686,10 @@ def hello():
 
 \subsection{Watermarks}
 
-\begin{frame}[fragile]{watermark --- diagonal slide annotation}
+\begin{frame}[fragile]{watermark --- footer annotation}
   \watermark{TODO}
-  \inlinecode{\\watermark[color]\{text\}} places a diagonal, semi-transparent text overlay
-  across the slide to flag work-in-progress slides.
+  \inlinecode{\\watermark[color]\{text\}} places a small badge in the footer
+  to flag work-in-progress slides.
   The default color is \inlinecode{alert} (adapts to dark/light mode automatically).
 
   \vspace{0.4em}

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,8 @@
-% !TEX program = xelatex
+% !TEX program = lualatex
 % !TEX options = -shell-escape -synctex=1 -interaction=nonstopmode -file-line-error "%DOC%"
 % chktex-file 8
 % chktex-file 11
+% chktex-file 13
 % chktex-file 18
 % chktex-file 36
 \documentclass[presentation, aspectratio=169]{beamer}
@@ -33,6 +34,8 @@
 \usepackage[justification=centering]{caption}
 \usepackage{appendixnumberbeamer}
 \usepackage{fontawesome5}
+\usepackage{emoji}
+\setemojifont{Noto Color Emoji}
 \usepackage[skins]{tcolorbox}
 \usepackage[version=4]{mhchem}
 \usepackage{tikz}
@@ -85,6 +88,9 @@
 
 % Helper for the FontAwesome icon table: icon + command name
 \newcommand{\farow}[2]{\makebox[1.4em]{\large#1}\,{\small\inlinecode{#2}}}
+
+% Helper for the emoji table: emoji + name as inlinecode
+\newcommand{\emorow}[1]{\makebox[1.6em]{\emoji{#1}}\,{\small\inlinecode{#1}}}
 
 % Show a mini ToC (current section highlighted) at the start of each section
 \AtBeginSection[]{%
@@ -531,6 +537,47 @@
   \end{columns}
 \end{frame}
 
+\subsection{Emojis}
+
+\begin{frame}[fragile]{Emojis}
+  Load \inlinecode{\\usepackage\{emoji\}} (LuaLaTeX only).
+  Use \inlinecode{\\emoji\{name\}} with Unicode CLDR short names (hyphens for spaces):
+
+  \vspace{0.3em}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.3\textwidth}
+      \textbf{People \& Symbols}\\[0.3em]
+      \emorow{grinning-face}\\[0.15em]
+      \emorow{thumbs-up}\\[0.15em]
+      \emorow{warning}\\[0.15em]
+      \emorow{check-mark-button}\\[0.15em]
+      \emorow{red-heart}\\[0.15em]
+      \emorow{fire}
+    \end{column}
+    \begin{column}{0.3\textwidth}
+      \textbf{Nature \& Climate}\\[0.3em]
+      \emorow{sun}\\[0.15em]
+      \emorow{snowflake}\\[0.15em]
+      \emorow{cloud-with-rain}\\[0.15em]
+      \emorow{thermometer}\\[0.15em]
+      \emorow{rainbow}\\[0.35em]
+      \emorow{globe-showing-europe-africa}
+    \end{column}
+    \begin{column}{0.35\textwidth}
+      \textbf{Tech \& Science}\\[0.3em]
+      \emorow{snake}\\[0.15em]
+      \emorow{rocket}\\[0.15em]
+      \emorow{bar-chart}\\[0.15em]
+      \emorow{light-bulb}\\[0.15em]
+      \emorow{laptop}\\[1.55em]
+      {\small Inline: I \emoji{red-heart} \LaTeX\@!}\\[0.3em]
+      \begin{codeblock}
+I \emoji{red-heart} LaTeX!
+      \end{codeblock}
+    \end{column}
+  \end{columns}
+\end{frame}
+
 % ═════════════════════════════════════════════════════════════
 \section{Code}
 % ═════════════════════════════════════════════════════════════
@@ -605,6 +652,6 @@ def hello():
 %%% Local Variables:
 %%% coding: utf-8
 %%% mode: latex
-%%% TeX-engine: xetex
+%%% TeX-engine: luatex
 %%% TeX-command-extra-options: "-shell-escape"
 %%% End:

--- a/main.tex
+++ b/main.tex
@@ -32,7 +32,7 @@
 \usepackage{import}
 \usepackage[justification=centering]{caption}
 \usepackage{appendixnumberbeamer}
-\usepackage{fontawesome}
+\usepackage{fontawesome5}
 \usepackage[skins]{tcolorbox}
 \usepackage[version=4]{mhchem}
 \usepackage{tikz}
@@ -82,6 +82,9 @@
 \defbeamertemplate{subsection in toc}{smalldot}{%
   \leavevmode\leftskip=1.7em\hspace{0.3em}\inserttocsubsection\par%
 }
+
+% Helper for the FontAwesome icon table: icon + command name
+\newcommand{\farow}[2]{\makebox[1.4em]{\large#1}\,{\small\inlinecode{#2}}}
 
 % Show a mini ToC (current section highlighted) at the start of each section
 \AtBeginSection[]{%
@@ -452,6 +455,80 @@
 
   \vspace{0.3em}
   Overlay spec example: \plum{2}<2>{this text is plum-colored only on slide~2}
+\end{frame}
+
+\subsection{Icons (FontAwesome 5)}
+
+\begin{frame}[fragile]{Icons --- Web \& UI / Programming \& Dev}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.32\textwidth}
+      \textbf{Web \& UI}\\[0.3em]
+      \farow{\faGlobe}{\textbackslash{}faGlobe}\\[0.15em]
+      \farow{\faHome}{\textbackslash{}faHome}\\[0.15em]
+      \farow{\faEnvelope}{\textbackslash{}faEnvelope}\\[0.15em]
+      \farow{\faLink}{\textbackslash{}faLink}\\[0.15em]
+      \farow{\faLock}{\textbackslash{}faLock}\\[0.15em]
+      \farow{\faUser}{\textbackslash{}faUser}\\[0.15em]
+      \farow{\faSearch}{\textbackslash{}faSearch}\\[0.15em]
+      \farow{\faCog}{\textbackslash{}faCog}
+    \end{column}
+    \begin{column}{0.32\textwidth}
+      \textbf{Programming \& Dev}\\[0.3em]
+      \farow{\faGithub}{\textbackslash{}faGithub}\\[0.15em]
+      \farow{\faGitlab}{\textbackslash{}faGitlab}\\[0.15em]
+      \farow{\faPython}{\textbackslash{}faPython}\\[0.15em]
+      \farow{\faDocker}{\textbackslash{}faDocker}\\[0.15em]
+      \farow{\faTerminal}{\textbackslash{}faTerminal}\\[0.15em]
+      \farow{\faCode}{\textbackslash{}faCode}\\[0.15em]
+      \farow{\faDatabase}{\textbackslash{}faDatabase}\\[0.15em]
+      \farow{\faBug}{\textbackslash{}faBug}
+    \end{column}
+    \begin{column}{0.32\textwidth}
+      \textbf{Coloring icons}\\[0.3em]
+      {\small Use \inlinecode{\\textcolor} or a color group:}\\[0.5em]
+      \textcolor{orange}{\farow{\faGlobe}{\textbackslash{}faGlobe}}\\[0.15em]
+      \textcolor{cyan}{\farow{\faPython}{\textbackslash{}faPython}}\\[0.15em]
+      \textcolor{red}{\farow{\faBug}{\textbackslash{}faBug}}\\[0.15em]
+      \textcolor{green}{\farow{\faCheck}{\textbackslash{}faCheck}}\\[0.5em]
+      {\small Inline: \textcolor{yellow}{\faStar}\,%
+      \textcolor{plum}{\faStar}\,%
+      \textcolor{petrol}{\faStar}}\\[0.4em]
+      \begin{codeblock}
+\\textcolor\{orange\}\{\\faGlobe\}
+\{\\color\{cyan\}\\faPython\}
+      \end{codeblock}
+    \end{column}
+  \end{columns}
+\end{frame}
+
+\begin{frame}{Icons --- Weather \& Climate}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.32\textwidth}
+      \farow{\faSun}{\textbackslash{}faSun}\\[0.2em]
+      \farow{\faCloud}{\textbackslash{}faCloud}\\[0.2em]
+      \farow{\faCloudSun}{\textbackslash{}faCloudSun}\\[0.2em]
+      \farow{\faCloudRain}{\textbackslash{}faCloudRain}\\[0.2em]
+      \farow{\faCloudShowersHeavy}{\textbackslash{}faCloudShowersHeavy}\\[0.2em]
+      \farow{\faCloudMoonRain}{\textbackslash{}faCloudMoonRain}
+    \end{column}
+    \begin{column}{0.32\textwidth}
+      \farow{\faSnowflake}{\textbackslash{}faSnowflake}\\[0.2em]
+      \farow{\faBolt}{\textbackslash{}faBolt}\\[0.2em]
+      \farow{\faWind}{\textbackslash{}faWind}\\[0.2em]
+      \farow{\faSmog}{\textbackslash{}faSmog}\\[0.2em]
+      \farow{\faRainbow}{\textbackslash{}faRainbow}\\[0.2em]
+      \farow{\faThermometerHalf}{\textbackslash{}faThermometerHalf}
+    \end{column}
+    \begin{column}{0.32\textwidth}
+      \textbf{Colored weather icons}\\[0.4em]
+      \textcolor{yellow}{\farow{\faSun}{\textbackslash{}faSun}}\\[0.2em]
+      \textcolor{cyan}{\farow{\faSnowflake}{\textbackslash{}faSnowflake}}\\[0.2em]
+      \textcolor{blue}{\farow{\faCloudRain}{\textbackslash{}faCloudRain}}\\[0.2em]
+      \textcolor{orange}{\farow{\faBolt}{\textbackslash{}faBolt}}\\[0.2em]
+      \textcolor{petrol}{\farow{\faWind}{\textbackslash{}faWind}}\\[0.2em]
+      \textcolor{red}{\farow{\faThermometerHalf}{\textbackslash{}faThermometerHalf}}
+    \end{column}
+  \end{columns}
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════

--- a/main.tex
+++ b/main.tex
@@ -67,6 +67,40 @@
   pdflang={English}
 }
 
+% Compact inline circle template for ToC slides (avoids the oversized llap circles)
+\defbeamertemplate{section in toc}{smallcircle}{%
+  \leavevmode%
+  \usebeamerfont*{section number projected}%
+  \usebeamercolor{section number projected}%
+  \tikz[baseline=(char.base), inner sep=0pt, outer sep=0pt]{%
+    \node[circle, fill=bg, text=fg, inner sep=1.5pt,%
+          font=\footnotesize\bfseries, minimum size=1.4em] (char) {\inserttocsectionnumber};%
+  }\hspace{0.3em}%
+  \inserttocsection\par%
+}
+
+\defbeamertemplate{subsection in toc}{smalldot}{%
+  \leavevmode\leftskip=1.7em\hspace{0.3em}\inserttocsubsection\par%
+}
+
+% Show a mini ToC (current section highlighted) at the start of each section
+\AtBeginSection[]{%
+  \begingroup%
+  \setbeamertemplate{section in toc}[smallcircle]%
+  \setbeamertemplate{subsection in toc}[smalldot]%
+  \begin{frame}{Outline}
+    \begin{columns}[t, onlytextwidth]
+      \begin{column}{0.48\textwidth}
+        \tableofcontents[currentsection, hideothersubsections, sections={1-3}]
+      \end{column}
+      \begin{column}{0.48\textwidth}
+        \tableofcontents[currentsection, hideothersubsections, sections={4-6}]
+      \end{column}
+    \end{columns}
+  \end{frame}%
+  \endgroup%
+}
+
 \begin{document}
 
 \maketitle
@@ -74,15 +108,19 @@
 % ─────────────────────────────────────────────────────────────
 % Table of Contents
 % ─────────────────────────────────────────────────────────────
+\begingroup%
+\setbeamertemplate{section in toc}[smallcircle]%
+\setbeamertemplate{subsection in toc}[smalldot]%
 \begin{frame}{Table of Contents}
-  \tableofcontents
-\end{frame}
+  \tableofcontents[hideallsubsections]
+\end{frame}%
+\endgroup
 
 % ═════════════════════════════════════════════════════════════
-\part{Theme Setup}
+\section{Theme Setup}
 % ═════════════════════════════════════════════════════════════
 
-\section{Dark \& Light Mode}
+\subsection{Dark \& Light Mode}
 
 \begin{frame}[fragile]{Dark \& Light Mode}
   Switch between dark and light mode by passing (or omitting) the \inlinecode{darkmode} option:
@@ -107,7 +145,7 @@
   All colors, logos, and backgrounds switch automatically between the two palettes.
 \end{frame}
 
-\section{Date \& Footer}
+\subsection{Date \& Footer}
 
 \begin{frame}[fragile]{Date \& Footer}
   The footer date is controlled by \inlinecode{\\mydatefootnote} and the title date by \inlinecode{\\mydate}.
@@ -133,10 +171,10 @@
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════
-\part{Colors}
+\section{Colors}
 % ═════════════════════════════════════════════════════════════
 
-\section{Theme Color Palette}
+\subsection{Theme Color Palette}
 
 \begin{frame}{Theme Color Palette}
   Named colors defined by the theme, adapting automatically to dark/light mode:
@@ -167,7 +205,7 @@
   Use with \inlinecode{\\textcolor\{orange\}\{text\}} or \inlinecode{\\color\{green\}}.
 \end{frame}
 
-\section{Tango Colors}
+\subsection{Tango Colors}
 
 \begin{frame}{Tango Color Palette \& Commands}
   The \inlinecode{tango} package provides fixed named colors and overlay-aware commands.
@@ -200,10 +238,10 @@
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════
-\part{Blocks \& Boxes}
+\section{Blocks \& Boxes}
 % ═════════════════════════════════════════════════════════════
 
-\section{Standard Blocks}
+\subsection{Standard Blocks}
 
 \begin{frame}{Standard Blocks}
   Three built-in block types whose colors follow dark/light mode automatically:
@@ -227,7 +265,7 @@
   \end{exampleblock}
 \end{frame}
 
-\section{Custom Blocks \& Overlays}
+\subsection{Custom Blocks \& Overlays}
 
 \begin{frame}{customblock --- custom color, overlays \& overprint}
   \inlinecode{customblock} accepts \inlinecode{bgcolor=} and \inlinecode{itcolor=} and supports overlay specs.
@@ -261,7 +299,7 @@
   \end{overprint}
 \end{frame}
 
-\section{Color Boxes}
+\subsection{Color Boxes}
 
 \begin{frame}{framebox \& customcolbox}
   \begin{columns}
@@ -316,7 +354,7 @@
   \end{taskproposal}
 \end{frame}
 
-\section{Priority Boxes}
+\subsection{Priority Boxes}
 
 \begin{frame}{priority --- color-coded priority levels}
   \inlinecode{\\begin\{priority\}\{A|B|C|D\}} maps to four color levels:
@@ -340,10 +378,10 @@
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════
-\part{Lists \& Text}
+\section{Lists \& Text}
 % ═════════════════════════════════════════════════════════════
 
-\section{Lists \& Overlays}
+\subsection{Lists \& Overlays}
 
 \begin{frame}{Lists}
   \begin{columns}
@@ -384,7 +422,7 @@
   \note{Presenter notes go here with \\note\{...\} inside the frame.}
 \end{frame}
 
-\section{Inline Elements \& Annotations}
+\subsection{Inline Elements \& Annotations}
 
 \begin{frame}{Inline Elements \& Annotations}
   \begin{itemize}
@@ -417,10 +455,10 @@
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════
-\part{Code}
+\section{Code}
 % ═════════════════════════════════════════════════════════════
 
-\section{Code Blocks}
+\subsection{Code Blocks}
 
 \begin{frame}[fragile]{Code Environments}
   Two environments for displaying code:
@@ -441,10 +479,10 @@ def hello():
 \end{frame}
 
 % ═════════════════════════════════════════════════════════════
-\part{Graphics \& Layout}
+\section{Graphics \& Layout}
 % ═════════════════════════════════════════════════════════════
 
-\section{Columns \& Multi-Line Titles}
+\subsection{Columns \& Multi-Line Titles}
 
 \begin{frame}{The frame title over 2 lines \\ logo still works!}
   Wrap long frame titles with \inlinecode{\\\\}. Logos and footer stay in place.
@@ -464,7 +502,7 @@ def hello():
   \end{columns}
 \end{frame}
 
-\section{Background Images}
+\subsection{Background Images}
 
 \begin{frame}{bgfig --- overlay image on page}
   \bgfig{./Graphics/background_title_page_dark.png}{opacity=0.15}{width=0.5\paperwidth}
@@ -480,7 +518,7 @@ def hello():
   \end{itemize}
 \end{frame}
 
-\section{Full-Frame Graphics}
+\subsection{Full-Frame Graphics}
 
 % \plainFrameGraphics inserts a plain frame (no chrome) with the image filling the slide
 \plainFrameGraphics{./Graphics/background_title_page_dark.png}

--- a/main.tex
+++ b/main.tex
@@ -50,8 +50,8 @@
 }
 
 % Set dates for title and footnote
-\def\mydate{December 24, 2022}
-\def\mydatefootnote{2022-12-24}
+\def\mydate{March 06, 2026}
+\def\mydatefootnote{2026-03-06}
 
 \usetheme[darkmode]{C2SM}
 \author{My wonderful self}

--- a/main.tex
+++ b/main.tex
@@ -68,22 +68,26 @@
 % Set dark or light mode by passing the darkmode option to the theme:
 \usetheme[darkmode]{C2SM}
 
-% Optional title page elements (must come after \usetheme, which resets these to empty)
-\def\affiliations{\affil{1}{Center for Climate Systems Modeling (C2SM), ETH Zurich}}
-\def\location{Zürich, Switzerland}
-\def\event{Our awesome event}
+% Add authors for title page
+\addauthor{Matthieu Leclair}{1}
+\addauthor{Michael Jähn}{1}
+\addauthor{John Doe}{}
 
-% Set PDF metadata (author, title, keywords, subject, creator, language)
-\author{Matthieu Leclair\textsuperscript{1}, Michael Jähn\textsuperscript{1}}
+% Add affiliations for title page
+\addaffil{1}{Center for Climate Systems Modeling (C2SM), ETH Zurich}
+
+% Optional title page elements (must come after \usetheme, which resets these to empty)
 \date{\mydate}
-\title{The Title}
-\subtitle{The more verbose Subtitle}
+\def\event{Our awesome event}
+\def\location{Zürich, Switzerland}
+
+% Set PDF metadata
+\title{C2SM Beamer Template}
+\subtitle{With practical examples}
 \hypersetup{
-  pdfauthor={My wonderful self},
-  pdftitle={The Title},
-  pdfkeywords={},
+  pdfauthor={\authorplain},
   pdfsubject={},
-  pdfcreator={}, 
+  pdfkeywords={},
   pdflang={English}
 }
 

--- a/main.tex
+++ b/main.tex
@@ -67,104 +67,77 @@
 
 \maketitle
 
-\part{First part}
-
-\begin{frame}{The frame title}
-  \note{note
-    Talk no more than 1 minute.}
-
-  \begin{block}<1->{A normal block}
-    \begin{itemize}
-    \item Hello World
-    \item The 2 following blocks are in an \inlinecode{overprint} environment
-    \end{itemize}
-  \end{block}
-
-  \begin{overprint}
-    \onslide<2>
-
-    An overprint environment: Blocks replacing this text don't make the following move.
-    
-    \onslide<3>
-
-    \begin{customblock}<2->[bgcolor=plum, itcolor=plum]{A custom color block with columns}
-      \begin{columns}
-        \begin{column}{0.6\columnwidth}
-          Some definitions:
-          \begin{description}
-          \item[{toto}] some blabla
-          \item[{tata}] another blabla
-          \end{description}
-        \end{column}
-
-        \begin{column}{0.3\columnwidth}
-          enumerate env:
-          \begin{enumerate}
-          \item something
-          \item Something else
-          \end{enumerate}
-        \end{column}
-      \end{columns}
-    \end{customblock}
-
-    \onslide<4->
-
-    \begin{exampleblock}{An example block}
-      Hello
-    \end{exampleblock}
-  \end{overprint}
-
-  \onslide<2->
-  \begin{enumerate}
-  \item first item
-  \item second item
-    \setcounter{enumi}{5}
-  \item Changing enum counter
-  \end{enumerate}
-\end{frame}
-
-\part{Second part}
-
-\begin{frame}{Frame title 2}
-  Some blabla
-  \begin{itemize}
-  \item super exciting results
-  \item even more awesome
-  \end{itemize}
-\end{frame}
-
-\begin{frame}{The frame title over 2 lines \\  logo still works!}
-  \begin{alertblock}{An alerted block}
-    \begin{enumerate}
-    \item toto
-    \item tata
-    \item tutu
-    \end{enumerate}
-  \end{alertblock}
-\end{frame}
-
-\begin{frame}[fragile]
-  \frametitle{Dark mode}
-  You can compile in \alert{dark mode} using
-\begin{codeblock}
-\\usetheme\alert{[darkmode]}\{C2SM\}
-\end{codeblock}
-\end{frame}
-
-\part{Theme Colors}
-
-% Table of contents
-% =================
+% ─────────────────────────────────────────────────────────────
+% Table of Contents
+% ─────────────────────────────────────────────────────────────
 \begin{frame}{Table of Contents}
   \tableofcontents
 \end{frame}
 
-% Color palette
-% =============
-\begin{frame}{Theme Color Palette}
-  The following named colors are available in both dark and light mode:
-  \vspace{0.5em}
+% ═════════════════════════════════════════════════════════════
+\part{Theme Setup}
+% ═════════════════════════════════════════════════════════════
 
+\section{Dark \& Light Mode}
+
+\begin{frame}[fragile]{Dark \& Light Mode}
+  Switch between dark and light mode by passing (or omitting) the \inlinecode{darkmode} option:
+
+  \vspace{0.4em}
+  \begin{columns}
+    \begin{column}{0.45\columnwidth}
+      \textbf{Dark mode} (current):
+\begin{codeblock}
+\\usetheme\alert{[darkmode]}\{C2SM\}
+\end{codeblock}
+    \end{column}
+    \begin{column}{0.45\columnwidth}
+      \textbf{Light mode}:
+\begin{codeblock}
+\\usetheme\{C2SM\}
+\end{codeblock}
+    \end{column}
+  \end{columns}
+
+  \vspace{0.4em}
+  All colors, logos, and backgrounds switch automatically between the two palettes.
+\end{frame}
+
+\section{Date \& Footer}
+
+\begin{frame}[fragile]{Date \& Footer}
+  The footer date is controlled by \inlinecode{\\mydatefootnote} and the title date by \inlinecode{\\mydate}.
+  Use \inlinecode{\\currentdate} to insert today as \inlinecode{YYYY-MM-DD} automatically:
+
+  \vspace{0.4em}
+  \begin{columns}
+    \begin{column}{0.48\columnwidth}
+      \textbf{Fixed dates:}
+\begin{codeblock}
+\\def\\mydate\{December 24, 2022\}
+\\def\\mydatefootnote\{2022-12-24\}
+\end{codeblock}
+    \end{column}
+    \begin{column}{0.45\columnwidth}
+      \textbf{Automatic date:}
+\begin{codeblock}
+\\def\\mydatefootnote\{\\currentdate\}
+\end{codeblock}
+      Today: \currentdate
+    \end{column}
+  \end{columns}
+\end{frame}
+
+% ═════════════════════════════════════════════════════════════
+\part{Colors}
+% ═════════════════════════════════════════════════════════════
+
+\section{Theme Color Palette}
+
+\begin{frame}{Theme Color Palette}
+  Named colors defined by the theme, adapting automatically to dark/light mode:
+
+  \vspace{0.4em}
   \begin{columns}
     \begin{column}{0.45\columnwidth}
       \begin{itemize}
@@ -186,20 +159,18 @@
     \end{column}
   \end{columns}
 
-  \vspace{0.5em}
-  Use with: \inlinecode{\\textcolor\{orange\}\{text\}} or \inlinecode{\\color\{green\}}
+  \vspace{0.4em}
+  Use with \inlinecode{\\textcolor\{orange\}\{text\}} or \inlinecode{\\color\{green\}}.
 \end{frame}
 
-\part{Tango Colors}
+\section{Tango Colors}
 
-% Tango color commands
-% ====================
 \begin{frame}{Tango Color Palette \& Commands}
-  The \inlinecode{tango} package provides named colors and overlay-aware commands.
+  The \inlinecode{tango} package provides fixed named colors and overlay-aware commands.
 
-  \vspace{0.5em}
+  \vspace{0.3em}
   \begin{columns}
-    \begin{column}{0.45\columnwidth}
+    \begin{column}{0.48\columnwidth}
       \textbf{Commands:} \inlinecode{\\plum\{depth\}\{text\}}\\[0.4em]
       \plum{1}{Plum1} \quad \plum{2}{Plum2} \quad \plum{3}{Plum3}\\
       \skyblue{1}{SkyBlue1} \quad \skyblue{2}{SkyBlue2} \quad \skyblue{3}{SkyBlue3}\\
@@ -224,71 +195,127 @@
   \end{columns}
 \end{frame}
 
-\part{Box Environments}
+% ═════════════════════════════════════════════════════════════
+\part{Blocks \& Boxes}
+% ═════════════════════════════════════════════════════════════
 
-% framebox
-% ========
-\begin{frame}{framebox --- single color tcolorbox}
-  \inlinecode{framebox} takes one color and derives border + tinted background from it.
+\section{Standard Blocks}
 
-  \vspace{0.5em}
-  \begin{framebox}{green}
-    This is a \inlinecode{framebox} in \inlinecode{green}.
+\begin{frame}{Standard Blocks}
+  Three built-in block types whose colors follow dark/light mode automatically:
+
+  \vspace{0.3em}
+  \begin{block}{block --- general information}
+    Use for neutral content. Item bullet colors match the block accent color.
     \begin{itemize}
-      \item Item colors follow the box color automatically
-      \item Any theme color works: \inlinecode{red}, \inlinecode{blue}, \inlinecode{orange}, \ldots
+      \item Hello World
     \end{itemize}
-  \end{framebox}
+  \end{block}
 
-  \vspace{0.5em}
-  \begin{framebox}[title=Optional tcolorbox options]{orange}
-    You can pass extra \inlinecode{tcolorbox} options as the optional first argument.
-  \end{framebox}
+  \vspace{0.3em}
+  \begin{alertblock}{alertblock --- warnings or key points}
+    Use to draw attention to important information.
+  \end{alertblock}
+
+  \vspace{0.3em}
+  \begin{exampleblock}{exampleblock --- examples or results}
+    Use for examples, code output, or tips.
+  \end{exampleblock}
 \end{frame}
 
-% customcolbox
-% ============
-\begin{frame}{customcolbox --- colored content box without title}
-  \inlinecode{customcolbox} is like \inlinecode{customblock} but has no title bar.
+\section{Custom Blocks \& Overlays}
 
-  \vspace{0.5em}
-  \begin{customcolbox}{cyan}
-    A \inlinecode{customcolbox} in \inlinecode{cyan}: no title, tinted background.
-    \begin{itemize}
-      \item List colors follow the chosen color
-      \item Good for side notes or highlighted content
-    \end{itemize}
-  \end{customcolbox}
+\begin{frame}{customblock --- custom color, overlays \& overprint}
+  \inlinecode{customblock} accepts \inlinecode{bgcolor=} and \inlinecode{itcolor=} and supports overlay specs.
 
-  \vspace{0.5em}
-  \begin{customcolbox}{plum}
-    Same box in \inlinecode{plum}.
-  \end{customcolbox}
+  \begin{block}<1->{Visible from slide 1}
+    Always visible. The \inlinecode{overprint} below replaces content without shifting layout.
+  \end{block}
+
+  \begin{overprint}
+    \onslide<2>
+    \vspace{0.3em}
+    Plain text on slide~2 inside \inlinecode{overprint} --- the block above does not move.
+
+    \onslide<3->
+    \begin{customblock}<3->[bgcolor=plum, itcolor=plum]{customblock with bgcolor=plum (slide 3+)}
+      \begin{columns}
+        \begin{column}{0.55\columnwidth}
+          \begin{description}
+            \item[bgcolor] sets title and background tint color
+            \item[itcolor] sets bullet/enumerate color
+          \end{description}
+        \end{column}
+        \begin{column}{0.35\columnwidth}
+          \begin{enumerate}
+            \item red, blue, green
+            \item orange, plum, cyan\ldots
+          \end{enumerate}
+        \end{column}
+      \end{columns}
+    \end{customblock}
+  \end{overprint}
 \end{frame}
 
-% background & taskproposal
-% =========================
-\begin{frame}{background \& taskproposal environments}
+\section{Color Boxes}
+
+\begin{frame}{framebox \& customcolbox}
+  \begin{columns}
+    \begin{column}{0.48\columnwidth}
+      \textbf{\inlinecode{framebox\{color\}}} --- bordered tcolorbox:
+      \vspace{0.3em}
+      \begin{framebox}{green}
+        Border + tinted background from one color.
+        \begin{itemize}
+          \item Bullet colors follow automatically
+        \end{itemize}
+      \end{framebox}
+      \vspace{0.3em}
+      \begin{framebox}[title=With extra tcolorbox options]{orange}
+        Pass extra tcolorbox options as the first optional argument.
+      \end{framebox}
+    \end{column}
+    \begin{column}{0.48\columnwidth}
+      \textbf{\inlinecode{customcolbox\{color\}}} --- titleless box:
+      \vspace{0.3em}
+      \begin{customcolbox}{cyan}
+        No title bar, tinted background; good for side notes or highlights.
+        \begin{itemize}
+          \item Bullet colors follow automatically
+        \end{itemize}
+      \end{customcolbox}
+      \vspace{0.3em}
+      \begin{customcolbox}{plum}
+        Same environment in \inlinecode{plum}.
+      \end{customcolbox}
+    \end{column}
+  \end{columns}
+\end{frame}
+
+\begin{frame}{background \& taskproposal --- preset boxes}
+  Fixed-color boxes for recurring use cases:
+
+  \vspace{0.3em}
   \begin{background}
-    \textbf{Background:} fixed Plum3 styled box for contextual information.
+    \textbf{background} --- Plum3 box for contextual information.
     \begin{itemize}
-      \item Use this to provide background knowledge
+      \item Use this to provide background knowledge before the main content
     \end{itemize}
   \end{background}
 
-  \vspace{0.5em}
+  \vspace{0.4em}
   \begin{taskproposal}
-    \textbf{Task Proposal:} fixed SkyBlue3 styled box for proposed tasks.
+    \textbf{taskproposal} --- SkyBlue3 box for proposed tasks or action items.
     \begin{itemize}
-      \item Use this to outline work items or proposals
+      \item Use this to outline work items or next steps
     \end{itemize}
   \end{taskproposal}
 \end{frame}
 
-% priority
-% ========
-\begin{frame}{priority environment --- color-coded boxes}
-  \inlinecode{priority\{A\}} through \inlinecode{priority\{D\}} for color-coded priorities.
+\section{Priority Boxes}
+
+\begin{frame}{priority --- color-coded priority levels}
+  \inlinecode{\\begin\{priority\}\{A|B|C|D\}} maps to four color levels:
 
   \vspace{0.3em}
   \begin{priority}{A}
@@ -308,69 +335,151 @@
   \end{priority}
 \end{frame}
 
-\part{Arrows \& Graphics}
+% ═════════════════════════════════════════════════════════════
+\part{Lists \& Text}
+% ═════════════════════════════════════════════════════════════
 
-% beamerarrow
-% ===========
-\begin{frame}{\textbackslash beamerarrow --- inline filled arrow}
-  Use \inlinecode{\\beamerarrow} as an inline directional element:
+\section{Lists \& Overlays}
 
-  \vspace{0.5em}
-  Step 1 \beamerarrow\ Step 2 \beamerarrow\ Step 3
+\begin{frame}{Lists}
+  \begin{columns}
+    \begin{column}{0.3\columnwidth}
+      \textbf{itemize:}
+      \begin{itemize}
+        \item First
+        \item Second
+          \begin{itemize}
+            \item Sub-item
+          \end{itemize}
+      \end{itemize}
+    \end{column}
+    \begin{column}{0.3\columnwidth}
+      \textbf{enumerate:}
+      \begin{enumerate}
+        \item First
+        \item Second
+          \setcounter{enumi}{5}
+        \item Skipped to 6
+      \end{enumerate}
+    \end{column}
+    \begin{column}{0.3\columnwidth}
+      \textbf{description:}
+      \begin{description}
+        \item[Term A] explanation
+        \item[Term B] explanation
+      \end{description}
+    \end{column}
+  \end{columns}
 
-  \vspace{0.5em}
+  \vspace{0.4em}
+  Use \inlinecode{\\onslide<2->} or \inlinecode{\\item<2->} for incremental reveal:
   \begin{itemize}
-    \item Model run \beamerarrow\ Post-processing \beamerarrow\ Visualization
-    \item Works inline in text or itemize environments
+    \item<2-> This item appears on slide~2
+    \item<3-> This item appears on slide~3
   \end{itemize}
+  \note{Presenter notes go here with \\note\{...\} inside the frame.}
 \end{frame}
 
-% bgfig
-% =====
-\begin{frame}{bgfig --- background image positioned on page}
+\section{Inline Elements \& Annotations}
+
+\begin{frame}{Inline Elements \& Annotations}
+  \begin{itemize}
+    \item \inlinecode{\\inlinecode\{text\}} --- styled monospace box: \inlinecode{example}
+    \item \inlinecode{\\alert\{text\}} --- \alert{highlighted in the alert color}
+    \item \inlinecode{\\beamerarrow} --- inline arrow: Step 1 \beamerarrow\ Step 2 \beamerarrow\ Step 3
+  \end{itemize}
+
+  \vspace{0.4em}
+  \textbf{Tango text color commands} (overlay-aware): \inlinecode{\\plum\{depth\}\{text\}}
+
+  \vspace{0.3em}
+  \begin{columns}
+    \begin{column}{0.48\columnwidth}
+      \plum{2}{$\backslash$plum\{2\}\{...\}} \quad
+      \skyblue{2}{$\backslash$skyblue\{2\}\{...\}}\\[0.3em]
+      \chameleon{2}{$\backslash$chameleon\{2\}\{...\}} \quad
+      \orange{2}{$\backslash$orange\{2\}\{...\}}
+    \end{column}
+    \begin{column}{0.45\columnwidth}
+      \butter{2}{$\backslash$butter\{2\}\{...\}} \quad
+      \chocolate{2}{$\backslash$chocolate\{2\}\{...\}}\\[0.3em]
+      \scarletred{2}{$\backslash$scarletred\{2\}\{...\}} \quad
+      \aluminium{4}{$\backslash$aluminium\{4\}\{...\}}
+    \end{column}
+  \end{columns}
+
+  \vspace{0.3em}
+  Overlay spec example: \plum{2}<2>{this text is plum-colored only on slide~2}
+\end{frame}
+
+% ═════════════════════════════════════════════════════════════
+\part{Code}
+% ═════════════════════════════════════════════════════════════
+
+\section{Code Blocks}
+
+\begin{frame}[fragile]{Code Environments}
+  Two environments for displaying code:
+
+  \vspace{0.4em}
+  \textbf{\inlinecode{codeblock}} --- semi-verbatim with \inlinecode{\\alert} markup support:
+\begin{codeblock}
+def hello():
+    \alert{print("Hello, world!")}  % this line is highlighted
+\end{codeblock}
+
+  \vspace{0.4em}
+  \textbf{\inlinecode{minted}} --- syntax-highlighted (requires \inlinecode{-shell-escape}):
+  \begin{minted}{python}
+def hello():
+    print("Hello, world!")
+  \end{minted}
+\end{frame}
+
+% ═════════════════════════════════════════════════════════════
+\part{Graphics \& Layout}
+% ═════════════════════════════════════════════════════════════
+
+\section{Columns \& Multi-Line Titles}
+
+\begin{frame}{The frame title over 2 lines \\ logo still works!}
+  Wrap long frame titles with \inlinecode{\\\\}. Logos and footer stay in place.
+
+  \vspace{0.4em}
+  \begin{columns}
+    \begin{column}{0.48\columnwidth}
+      \begin{block}{Left column}
+        Use \inlinecode{columns} + \inlinecode{column} to split content side by side.
+      \end{block}
+    \end{column}
+    \begin{column}{0.48\columnwidth}
+      \begin{block}{Right column}
+        Column widths are set with \inlinecode{0.48\\columnwidth}.
+      \end{block}
+    \end{column}
+  \end{columns}
+\end{frame}
+
+\section{Background Images}
+
+\begin{frame}{bgfig --- overlay image on page}
   \bgfig{./Graphics/background_title_page_dark.png}{opacity=0.15}{width=0.5\paperwidth}
 
-  Use \inlinecode{\\bgfig\{file\}\{node options\}\{includegraphics options\}} to place
-  an image relative to the page center without affecting text layout.
+  \inlinecode{\\bgfig\{file\}\{node opts\}\{img opts\}} places an image relative to the page
+  center without affecting text layout.
 
-  \vspace{0.5em}
+  \vspace{0.4em}
   \begin{itemize}
-    \item \inlinecode{node options}: \inlinecode{xshift=}, \inlinecode{yshift=}, \inlinecode{opacity=}, \ldots
-    \item \inlinecode{includegraphics options}: \inlinecode{width=}, \inlinecode{height=}, \ldots
-    \item Overlay specifications are supported: \inlinecode{\\bgfig<2>\{...\}}
+    \item \inlinecode{node opts}: \inlinecode{xshift=5cm}, \inlinecode{yshift=-2cm}, \inlinecode{opacity=0.3}
+    \item \inlinecode{img opts}: \inlinecode{width=0.5\\paperwidth}, \inlinecode{height=0.4\\paperheight}
+    \item Overlay specs supported: \inlinecode{\\bgfig<2>\{...\}\{...\}\{...\}}
   \end{itemize}
 \end{frame}
 
-% plainFrameGraphics
-% ==================
+\section{Full-Frame Graphics}
+
+% \plainFrameGraphics inserts a plain frame (no chrome) with the image filling the slide
 \plainFrameGraphics{./Graphics/background_title_page_dark.png}
-
-\part{Light Mode}
-
-% light mode
-% ==========
-\begin{frame}[fragile]{Light mode}
-  To use \alert{light mode}, omit the \inlinecode{darkmode} option:
-\begin{codeblock}
-\\usetheme\{C2SM\}
-\end{codeblock}
-  All colors, logos, and backgrounds automatically switch to the light palette.
-\end{frame}
-
-% currentdate
-% ===========
-\begin{frame}{\textbackslash currentdate --- automatic date}
-  Use \inlinecode{\\currentdate} to insert today's date automatically as \inlinecode{YYYY-MM-DD}:
-
-  \vspace{0.5em}
-  Today is: \currentdate
-
-  \vspace{0.5em}
-  Useful for the footnote date:
-\begin{codeblock}
-\\def\\mydatefootnote\{\\currentdate\}
-\end{codeblock}
-\end{frame}
 
 \end{document}
 

--- a/main.tex
+++ b/main.tex
@@ -6,6 +6,7 @@
 % chktex-file 18
 % chktex-file 36
 \PassOptionsToPackage{table}{xcolor}  % load colortbl via xcolor before beamer claims xcolor
+\PassOptionsToPackage{colorlinks=true}{hyperref} % Must be set before beamer loads hyperref
 \documentclass[presentation, aspectratio=169]{beamer}
 % --- Fonts & Typography ---
 \usepackage{fontspec}                         % OpenType font selection (LuaLaTeX/XeLaTeX)

--- a/main.tex
+++ b/main.tex
@@ -1,6 +1,9 @@
 % !TEX program = xelatex
 % !TEX options = -shell-escape -synctex=1 -interaction=nonstopmode -file-line-error "%DOC%"
 % chktex-file 8
+% chktex-file 11
+% chktex-file 18
+% chktex-file 36
 \documentclass[presentation, aspectratio=169]{beamer}
 \usepackage{fontspec}
 \usepackage{graphicx}
@@ -121,9 +124,9 @@
     \begin{column}{0.45\columnwidth}
       \textbf{Automatic date:}
 \begin{codeblock}
-\\def\\mydatefootnote\{\\currentdate\}
+\\def\\mydatefootnote\{\\currentdate}
 \end{codeblock}
-      Today: \currentdate
+      Today: \currentdate{}
     \end{column}
   \end{columns}
 \end{frame}
@@ -386,7 +389,7 @@
   \begin{itemize}
     \item \inlinecode{\\inlinecode\{text\}} --- styled monospace box: \inlinecode{example}
     \item \inlinecode{\\alert\{text\}} --- \alert{highlighted in the alert color}
-    \item \inlinecode{\\beamerarrow} --- inline arrow: Step 1 \beamerarrow\ Step 2 \beamerarrow\ Step 3
+    \item \inlinecode{\\beamerarrow\{\}} --- inline arrow: Step 1 \beamerarrow{} Step 2 \beamerarrow{} Step 3
   \end{itemize}
 
   \vspace{0.4em}

--- a/main.tex
+++ b/main.tex
@@ -62,14 +62,19 @@
 \setemojifont{Noto Color Emoji}               % Emoji font (requires noto-fonts-extra)
 
 % Set dates for title and footnote
-\def\mydate{March 06, 2026}
+\def\mydate{09 March, 2026}
 \def\mydatefootnote{2026-03-06}
 
 % Set dark or light mode by passing the darkmode option to the theme:
 \usetheme[darkmode]{C2SM}
 
+% Optional title page elements (must come after \usetheme, which resets these to empty)
+\def\affiliations{\affil{1}{Center for Climate Systems Modeling (C2SM), ETH Zurich}}
+\def\location{Zürich, Switzerland}
+\def\event{Our awesome event}
+
 % Set PDF metadata (author, title, keywords, subject, creator, language)
-\author{My wonderful self}
+\author{Matthieu Leclair\textsuperscript{1}, Michael Jähn\textsuperscript{1}}
 \date{\mydate}
 \title{The Title}
 \subtitle{The more verbose Subtitle}

--- a/main.tex
+++ b/main.tex
@@ -684,6 +684,35 @@ def hello():
   \end{columns}
 \end{frame}
 
+\subsection{Watermarks}
+
+\begin{frame}[fragile]{watermark --- diagonal slide annotation}
+  \watermark{TODO}
+  \inlinecode{\\watermark[color]\{text\}} places a diagonal, semi-transparent text overlay
+  across the slide to flag work-in-progress slides.
+  The default color is \inlinecode{alert} (adapts to dark/light mode automatically).
+
+  \vspace{0.4em}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.48\textwidth}
+      \textbf{Default --- alert color:}
+\begin{codeblock}
+\\watermark\{TODO\}
+\end{codeblock}
+    \end{column}
+    \begin{column}{0.48\textwidth}
+      \textbf{Custom color:}
+\begin{codeblock}
+\\watermark[orange]\{DRAFT\}
+\end{codeblock}
+    \end{column}
+  \end{columns}
+
+  \vspace{0.3em}
+  Place \inlinecode{\\watermark} anywhere inside the \inlinecode{frame} environment.
+  The watermark does not affect the text layout.
+\end{frame}
+
 \subsection{Background Images}
 
 \begin{frame}{bgfig --- overlay image on page}

--- a/main.tex
+++ b/main.tex
@@ -5,6 +5,7 @@
 % chktex-file 13
 % chktex-file 18
 % chktex-file 36
+\PassOptionsToPackage{table}{xcolor}  % load colortbl via xcolor before beamer claims xcolor
 \documentclass[presentation, aspectratio=169]{beamer}
 % --- Fonts & Typography ---
 \usepackage{fontspec}                         % OpenType font selection (LuaLaTeX/XeLaTeX)
@@ -597,6 +598,39 @@
       \begin{codeblock}
 I \emoji{red-heart} LaTeX!
       \end{codeblock}
+    \end{column}
+  \end{columns}
+\end{frame}
+
+\subsection{Tables}
+
+\begin{frame}[fragile]{bluetable --- styled tabular with alternating rows}
+  \inlinecode{bluetable\{col spec\}} wraps a \inlinecode{tabular} with a dark header row and alternating body row shading.
+  Wrap header cell text in \inlinecode{\\textcolor\{white\}\{...\}} for readability on the dark background.
+
+  \vspace{0.4em}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.44\textwidth}
+      \begin{bluetable}{lcc}
+        \textcolor{white}{\textbf{Model}} &
+        \textcolor{white}{\textbf{Res.}} &
+        \textcolor{white}{\textbf{Domain}} \\
+        COSMO & 2.2\,km & Alpine \\
+        ICON  & 13\,km  & Europe \\
+        ECMWF & 9\,km   & Global \\
+      \end{bluetable}
+    \end{column}
+    \begin{column}{0.52\textwidth}
+\begin{codeblock}
+\\begin\{bluetable\}\{lcc\}
+  \\textcolor\{white\}\{\\textbf\{Model\}\} &
+  \\textcolor\{white\}\{\\textbf\{Res.\}\} &
+  \\textcolor\{white\}\{\\textbf\{Domain\}\} \\\\
+  COSMO & 2.2\\,km & Alpine \\\\
+  ICON  & 13\\,km  & Europe \\\\
+  ECMWF & 9\\,km   & Global \\\\
+\\end\{bluetable\}
+\end{codeblock}
     \end{column}
   \end{columns}
 \end{frame}

--- a/main.tex
+++ b/main.tex
@@ -463,6 +463,41 @@
   Overlay spec example: \plum{2}<2>{this text is plum-colored only on slide~2}
 \end{frame}
 
+\subsection{Hyperlinks \& URLs}
+
+\begin{frame}[fragile]{Hyperlinks \& URLs}
+  Two commands for linking, both using the \inlinecode{url} color defined by the theme:
+
+  \vspace{0.4em}
+  \begin{columns}[t, onlytextwidth]
+    \begin{column}{0.48\textwidth}
+      \textbf{\inlinecode{\\url\{...\}}} --- display a raw URL:
+      \vspace{0.3em}
+\begin{codeblock}
+\\url\{https://c2sm.ethz.ch\}
+\end{codeblock}
+      \vspace{0.3em}
+      Result: \url{https://c2sm.ethz.ch}
+    \end{column}
+    \begin{column}{0.48\textwidth}
+      \textbf{\inlinecode{\\href\{url\}\{text\}}} --- link text to a URL:
+      \vspace{0.3em}
+\begin{codeblock}
+\\href\{https://c2sm.ethz.ch\}\{C2SM website\}
+\end{codeblock}
+      \vspace{0.3em}
+      Result: \href{https://c2sm.ethz.ch}{C2SM website}
+    \end{column}
+  \end{columns}
+
+  \vspace{0.5em}
+  Link colors are set in the preamble via \inlinecode{\\hypersetup}:
+\begin{codeblock}
+\\hypersetup\{colorlinks=true, linkcolor=url, urlcolor=url\}
+\end{codeblock}
+  The \inlinecode{url} color switches automatically with dark/light mode.
+\end{frame}
+
 \subsection{Icons (FontAwesome 5)}
 
 \begin{frame}[fragile]{Icons --- Web \& UI / Programming \& Dev}

--- a/main.tex
+++ b/main.tex
@@ -151,6 +151,227 @@
 \end{codeblock}
 \end{frame}
 
+\part{Theme Colors}
+
+% Table of contents
+% =================
+\begin{frame}{Table of Contents}
+  \tableofcontents
+\end{frame}
+
+% Color palette
+% =============
+\begin{frame}{Theme Color Palette}
+  The following named colors are available in both dark and light mode:
+  \vspace{0.5em}
+
+  \begin{columns}
+    \begin{column}{0.45\columnwidth}
+      \begin{itemize}
+        \item \textcolor{red}{\rule{1em}{1em}}~\inlinecode{red}
+        \item \textcolor{blue}{\rule{1em}{1em}}~\inlinecode{blue}
+        \item \textcolor{green}{\rule{1em}{1em}}~\inlinecode{green}
+        \item \textcolor{orange}{\rule{1em}{1em}}~\inlinecode{orange}
+        \item \textcolor{yellow}{\rule{1em}{1em}}~\inlinecode{yellow}
+      \end{itemize}
+    \end{column}
+    \begin{column}{0.45\columnwidth}
+      \begin{itemize}
+        \item \textcolor{plum}{\rule{1em}{1em}}~\inlinecode{plum}
+        \item \textcolor{cyan}{\rule{1em}{1em}}~\inlinecode{cyan}
+        \item \textcolor{beige}{\rule{1em}{1em}}~\inlinecode{beige}
+        \item \textcolor{petrol}{\rule{1em}{1em}}~\inlinecode{petrol}
+        \item \textcolor{darkgray}{\rule{1em}{1em}}~\inlinecode{darkgray}
+      \end{itemize}
+    \end{column}
+  \end{columns}
+
+  \vspace{0.5em}
+  Use with: \inlinecode{\\textcolor\{orange\}\{text\}} or \inlinecode{\\color\{green\}}
+\end{frame}
+
+\part{Tango Colors}
+
+% Tango color commands
+% ====================
+\begin{frame}{Tango Color Palette \& Commands}
+  The \inlinecode{tango} package provides named colors and overlay-aware commands.
+
+  \vspace{0.5em}
+  \begin{columns}
+    \begin{column}{0.45\columnwidth}
+      \textbf{Commands:} \inlinecode{\\plum\{depth\}\{text\}}\\[0.4em]
+      \plum{1}{Plum1} \quad \plum{2}{Plum2} \quad \plum{3}{Plum3}\\
+      \skyblue{1}{SkyBlue1} \quad \skyblue{2}{SkyBlue2} \quad \skyblue{3}{SkyBlue3}\\
+      \chameleon{1}{Chameleon1} \quad \chameleon{2}{Chameleon2} \quad \chameleon{3}{Chameleon3}\\
+      \orange{1}{Orange1} \quad \orange{2}{Orange2} \quad \orange{3}{Orange3}\\
+      \butter{1}{Butter1} \quad \butter{2}{Butter2} \quad \butter{3}{Butter3}\\
+      \chocolate{1}{Choc.1} \quad \chocolate{2}{Choc.2} \quad \chocolate{3}{Choc.3}\\
+      \scarletred{1}{Red1} \quad \scarletred{2}{Red2} \quad \scarletred{3}{Red3}\\
+      \aluminium{1}{Alu1} \quad \aluminium{4}{Alu4} \quad \aluminium{6}{Alu6}
+    \end{column}
+    \begin{column}{0.45\columnwidth}
+      \textbf{Direct color names:}\\[0.4em]
+      \begin{itemize}
+        \item \textcolor{Plum1}{\rule{0.8em}{0.8em}}~\textcolor{Plum2}{\rule{0.8em}{0.8em}}~\textcolor{Plum3}{\rule{0.8em}{0.8em}}~Plum 1--3
+        \item \textcolor{SkyBlue1}{\rule{0.8em}{0.8em}}~\textcolor{SkyBlue2}{\rule{0.8em}{0.8em}}~\textcolor{SkyBlue3}{\rule{0.8em}{0.8em}}~SkyBlue 1--3
+        \item \textcolor{Chameleon1}{\rule{0.8em}{0.8em}}~\textcolor{Chameleon2}{\rule{0.8em}{0.8em}}~\textcolor{Chameleon3}{\rule{0.8em}{0.8em}}~Chameleon 1--3
+        \item \textcolor{Orange1}{\rule{0.8em}{0.8em}}~\textcolor{Orange2}{\rule{0.8em}{0.8em}}~\textcolor{Orange3}{\rule{0.8em}{0.8em}}~Orange 1--3
+        \item \textcolor{ScarletRed1}{\rule{0.8em}{0.8em}}~\textcolor{ScarletRed2}{\rule{0.8em}{0.8em}}~\textcolor{ScarletRed3}{\rule{0.8em}{0.8em}}~ScarletRed 1--3
+        \item \textcolor{Aluminium1}{\rule{0.8em}{0.8em}}~\textcolor{Aluminium3}{\rule{0.8em}{0.8em}}~\textcolor{Aluminium6}{\rule{0.8em}{0.8em}}~Aluminium 1--6
+      \end{itemize}
+    \end{column}
+  \end{columns}
+\end{frame}
+
+\part{Box Environments}
+
+% framebox
+% ========
+\begin{frame}{framebox --- single color tcolorbox}
+  \inlinecode{framebox} takes one color and derives border + tinted background from it.
+
+  \vspace{0.5em}
+  \begin{framebox}{green}
+    This is a \inlinecode{framebox} in \inlinecode{green}.
+    \begin{itemize}
+      \item Item colors follow the box color automatically
+      \item Any theme color works: \inlinecode{red}, \inlinecode{blue}, \inlinecode{orange}, \ldots
+    \end{itemize}
+  \end{framebox}
+
+  \vspace{0.5em}
+  \begin{framebox}[title=Optional tcolorbox options]{orange}
+    You can pass extra \inlinecode{tcolorbox} options as the optional first argument.
+  \end{framebox}
+\end{frame}
+
+% customcolbox
+% ============
+\begin{frame}{customcolbox --- colored content box without title}
+  \inlinecode{customcolbox} is like \inlinecode{customblock} but has no title bar.
+
+  \vspace{0.5em}
+  \begin{customcolbox}{cyan}
+    A \inlinecode{customcolbox} in \inlinecode{cyan}: no title, tinted background.
+    \begin{itemize}
+      \item List colors follow the chosen color
+      \item Good for side notes or highlighted content
+    \end{itemize}
+  \end{customcolbox}
+
+  \vspace{0.5em}
+  \begin{customcolbox}{plum}
+    Same box in \inlinecode{plum}.
+  \end{customcolbox}
+\end{frame}
+
+% background & taskproposal
+% =========================
+\begin{frame}{background \& taskproposal environments}
+  \begin{background}
+    \textbf{Background:} fixed Plum3 styled box for contextual information.
+    \begin{itemize}
+      \item Use this to provide background knowledge
+    \end{itemize}
+  \end{background}
+
+  \vspace{0.5em}
+  \begin{taskproposal}
+    \textbf{Task Proposal:} fixed SkyBlue3 styled box for proposed tasks.
+    \begin{itemize}
+      \item Use this to outline work items or proposals
+    \end{itemize}
+  \end{taskproposal}
+\end{frame}
+
+% priority
+% ========
+\begin{frame}{priority environment --- color-coded boxes}
+  \inlinecode{priority\{A\}} through \inlinecode{priority\{D\}} for color-coded priorities.
+
+  \vspace{0.3em}
+  \begin{priority}{A}
+    \textbf{Priority A} --- Chameleon3 (green): must do
+  \end{priority}
+  \vspace{0.2em}
+  \begin{priority}{B}
+    \textbf{Priority B} --- Orange3: should do
+  \end{priority}
+  \vspace{0.2em}
+  \begin{priority}{C}
+    \textbf{Priority C} --- ScarletRed3: could do
+  \end{priority}
+  \vspace{0.2em}
+  \begin{priority}{D}
+    \textbf{Priority D} --- Aluminium6 (grey): won't do for now
+  \end{priority}
+\end{frame}
+
+\part{Arrows \& Graphics}
+
+% beamerarrow
+% ===========
+\begin{frame}{\textbackslash beamerarrow --- inline filled arrow}
+  Use \inlinecode{\\beamerarrow} as an inline directional element:
+
+  \vspace{0.5em}
+  Step 1 \beamerarrow\ Step 2 \beamerarrow\ Step 3
+
+  \vspace{0.5em}
+  \begin{itemize}
+    \item Model run \beamerarrow\ Post-processing \beamerarrow\ Visualization
+    \item Works inline in text or itemize environments
+  \end{itemize}
+\end{frame}
+
+% bgfig
+% =====
+\begin{frame}{bgfig --- background image positioned on page}
+  \bgfig{./Graphics/background_title_page_dark.png}{opacity=0.15}{width=0.5\paperwidth}
+
+  Use \inlinecode{\\bgfig\{file\}\{node options\}\{includegraphics options\}} to place
+  an image relative to the page center without affecting text layout.
+
+  \vspace{0.5em}
+  \begin{itemize}
+    \item \inlinecode{node options}: \inlinecode{xshift=}, \inlinecode{yshift=}, \inlinecode{opacity=}, \ldots
+    \item \inlinecode{includegraphics options}: \inlinecode{width=}, \inlinecode{height=}, \ldots
+    \item Overlay specifications are supported: \inlinecode{\\bgfig<2>\{...\}}
+  \end{itemize}
+\end{frame}
+
+% plainFrameGraphics
+% ==================
+\plainFrameGraphics{./Graphics/background_title_page_dark.png}
+
+\part{Light Mode}
+
+% light mode
+% ==========
+\begin{frame}[fragile]{Light mode}
+  To use \alert{light mode}, omit the \inlinecode{darkmode} option:
+\begin{codeblock}
+\\usetheme\{C2SM\}
+\end{codeblock}
+  All colors, logos, and backgrounds automatically switch to the light palette.
+\end{frame}
+
+% currentdate
+% ===========
+\begin{frame}{\textbackslash currentdate --- automatic date}
+  Use \inlinecode{\\currentdate} to insert today's date automatically as \inlinecode{YYYY-MM-DD}:
+
+  \vspace{0.5em}
+  Today is: \currentdate
+
+  \vspace{0.5em}
+  Useful for the footnote date:
+\begin{codeblock}
+\\def\\mydatefootnote\{\\currentdate\}
+\end{codeblock}
+\end{frame}
+
 \end{document}
 
 %%% Local Variables:

--- a/main.tex
+++ b/main.tex
@@ -33,24 +33,9 @@
 \usepackage{import}
 \usepackage[justification=centering]{caption}
 \usepackage{appendixnumberbeamer}
-\usepackage{fontawesome5}
 \usepackage{emoji}
 \setemojifont{Noto Color Emoji}
-\usepackage[skins]{tcolorbox}
 \usepackage[version=4]{mhchem}
-\usepackage{tikz}
-\usetikzlibrary{math}
-\usetikzlibrary{calc}
-\usetikzlibrary{positioning}
-\usetikzlibrary{fadings}
-
-% Set hyperlink color
-% (url color defined in beamerthemeC2SM.sty, chnages with dark/light mode)
-\hypersetup{
-  colorlinks=true,
-  linkcolor=url, % choose the color you want
-  urlcolor=url
-}
 
 % Set dates for title and footnote
 \def\mydate{March 06, 2026}
@@ -69,28 +54,6 @@
   pdfcreator={}, 
   pdflang={English}
 }
-
-% Compact inline circle template for ToC slides (avoids the oversized llap circles)
-\defbeamertemplate{section in toc}{smallcircle}{%
-  \leavevmode%
-  \usebeamerfont*{section number projected}%
-  \usebeamercolor{section number projected}%
-  \tikz[baseline=(char.base), inner sep=0pt, outer sep=0pt]{%
-    \node[circle, fill=bg, text=fg, inner sep=1.5pt,%
-          font=\footnotesize\bfseries, minimum size=1.4em] (char) {\inserttocsectionnumber};%
-  }\hspace{0.3em}%
-  \inserttocsection\par%
-}
-
-\defbeamertemplate{subsection in toc}{smalldot}{%
-  \leavevmode\leftskip=1.7em\hspace{0.3em}\inserttocsubsection\par%
-}
-
-% Helper for the FontAwesome icon table: icon + command name
-\newcommand{\farow}[2]{\makebox[1.4em]{\large#1}\,{\small\inlinecode{#2}}}
-
-% Helper for the emoji table: emoji + name as inlinecode
-\newcommand{\emorow}[1]{\makebox[1.6em]{\emoji{#1}}\,{\small\inlinecode{#1}}}
 
 % Show a mini ToC (current section highlighted) at the start of each section
 \AtBeginSection[]{%

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,8 @@
+% !TEX program = xelatex
+% !TEX options = -shell-escape -synctex=1 -interaction=nonstopmode -file-line-error "%DOC%"
+% chktex-file 8
 \documentclass[presentation, aspectratio=169]{beamer}
-\usepackage[T1]{fontenc}
+\usepackage{fontspec}
 \usepackage{graphicx}
 \usepackage{longtable}
 \usepackage{wrapfig}
@@ -11,7 +14,6 @@
 \usepackage{capt-of}
 \usepackage{hyperref}
 \usepackage{minted}
-\usepackage{fontspec}
 \usepackage[sfdefault,light]{roboto}
 \usepackage{beamertools}
 \usepackage{tango}
@@ -81,7 +83,7 @@
   \begin{overprint}
     \onslide<2>
 
-    An overprint environment : Blocks replacing this text don't make the following move.
+    An overprint environment: Blocks replacing this text don't make the following move.
     
     \onslide<3>
 

--- a/main.tex
+++ b/main.tex
@@ -159,8 +159,8 @@
     \begin{column}{0.48\columnwidth}
       \textbf{Fixed dates:}
 \begin{codeblock}
-\\def\\mydate\{December 24, 2022\}
-\\def\\mydatefootnote\{2022-12-24\}
+\\def\\mydate\{March 06, 2026\}
+\\def\\mydatefootnote\{2026-03-06\}
 \end{codeblock}
     \end{column}
     \begin{column}{0.45\columnwidth}

--- a/main.tex
+++ b/main.tex
@@ -63,7 +63,10 @@
 \def\mydate{March 06, 2026}
 \def\mydatefootnote{2026-03-06}
 
+% Set dark or light mode by passing the darkmode option to the theme:
 \usetheme[darkmode]{C2SM}
+
+% Set PDF metadata (author, title, keywords, subject, creator, language)
 \author{My wonderful self}
 \date{\mydate}
 \title{The Title}

--- a/main.tex
+++ b/main.tex
@@ -6,36 +6,58 @@
 % chktex-file 18
 % chktex-file 36
 \documentclass[presentation, aspectratio=169]{beamer}
-\usepackage{fontspec}
-\usepackage{graphicx}
-\usepackage{longtable}
-\usepackage{wrapfig}
-\usepackage{rotating}
-\usepackage[normalem]{ulem}
-\usepackage{amsmath}
-\usepackage[customcolors]{hf-tikz}
-\usepackage{amssymb}
-\usepackage{capt-of}
-\usepackage{hyperref}
-\usepackage{bookmark}
-\usepackage{minted}
-\usepackage[sfdefault,light]{roboto}
-\usepackage{beamertools}
-\usepackage{tango}
-\usepackage{setspace}
-\usepackage{pdfpages}
-\usepackage{booktabs}
-\usepackage{caption}
-\usepackage{tabularx,ragged2e}
-\usepackage{xcolor}
-\usepackage{pifont}
-\usepackage{array}
-\usepackage{import}
-\usepackage[justification=centering]{caption}
-\usepackage{appendixnumberbeamer}
-\usepackage{emoji}
-\setemojifont{Noto Color Emoji}
-\usepackage[version=4]{mhchem}
+% --- Fonts & Typography ---
+\usepackage{fontspec}                         % OpenType font selection (LuaLaTeX/XeLaTeX)
+\usepackage[sfdefault,light]{roboto}          % Roboto sans-serif as default font
+\usepackage{setspace}                         % Line-spacing control
+
+% --- Math & Chemistry ---
+\usepackage{amsmath}                          % Math environments (align, gather, …)
+\usepackage{amssymb}                          % AMS math symbols
+\usepackage[version=4]{mhchem}                % Chemical formulae (\ce{H2O})
+
+% --- Graphics & Figures ---
+\usepackage{graphicx}                         % \includegraphics
+\usepackage{wrapfig}                          % Text wrapped around figures
+\usepackage{rotating}                         % Rotate text and figures
+\usepackage{pdfpages}                         % Include external PDF pages
+\usepackage{capt-of}                          % \captionof outside float environments
+\usepackage[justification=centering]{caption} % Caption formatting and alignment
+
+% --- Tables ---
+\usepackage{longtable}                        % Tables spanning multiple pages
+\usepackage{booktabs}                         % Professional rules (\toprule, \midrule, …)
+\usepackage{tabularx,ragged2e}                % Flexible-width columns + ragged text
+\usepackage{array}                            % Extended column types for tabular/array
+
+% --- Colors & Symbols ---
+\usepackage{xcolor}                           % Extended color support
+\usepackage{pifont}                           % Dingbat symbols (\ding{51} = ✓)
+
+% --- TikZ ---
+\usepackage[customcolors]{hf-tikz}            % Highlight formula parts with TikZ
+
+% --- Hyperlinks & PDF Metadata ---
+\usepackage{hyperref}                         % Hyperlinks and PDF metadata
+\usepackage{bookmark}                         % Enhanced PDF bookmarks
+
+% --- Code Listing ---
+\usepackage{minted}                           % Syntax-highlighted code (requires -shell-escape)
+
+% --- Beamer Utilities ---
+\usepackage{appendixnumberbeamer}             % Correct slide numbering in appendix
+
+% --- Project-Local Packages ---
+\usepackage{beamertools}                      % Custom beamer commands (boxes, icons, …)
+\usepackage{tango}                            % Tango color palette
+
+% --- Misc / Layout ---
+\usepackage[normalem]{ulem}                   % Strikethrough (\sout) and underline variants
+\usepackage{import}                           % \import for relative path file inclusion
+
+% --- Emoji (LuaLaTeX only) ---
+\usepackage{emoji}                            % Unicode emoji via \emoji{name}
+\setemojifont{Noto Color Emoji}               % Emoji font (requires noto-fonts-extra)
 
 % Set dates for title and footnote
 \def\mydate{March 06, 2026}

--- a/main.tex
+++ b/main.tex
@@ -110,7 +110,7 @@
 \begingroup%
 \setbeamertemplate{section in toc}[smallcircle]%
 \setbeamertemplate{subsection in toc}[smalldot]%
-\begin{frame}{Table of Contents}
+\begin{frame}{Outline}
   \tableofcontents[hideallsubsections]
 \end{frame}%
 \endgroup

--- a/main.tex
+++ b/main.tex
@@ -743,6 +743,14 @@ def hello():
 % \plainFrameGraphics inserts a plain frame (no chrome) with the image filling the slide
 \plainFrameGraphics{./Graphics/background_title_page_dark.png}
 
+\appendix
+\setbeamertemplate{background}{}  % Clear the background for appendix slides
+% Backup Slides (not counted in total page number)
+\begin{frame}{Backup Slide 1}
+  % Add your backup content here
+  This is a backup slide example.
+\end{frame}
+
 \end{document}
 
 %%% Local Variables:

--- a/main.tex
+++ b/main.tex
@@ -16,6 +16,7 @@
 \usepackage{amssymb}
 \usepackage{capt-of}
 \usepackage{hyperref}
+\usepackage{bookmark}
 \usepackage{minted}
 \usepackage[sfdefault,light]{roboto}
 \usepackage{beamertools}
@@ -124,7 +125,7 @@
     \begin{column}{0.45\columnwidth}
       \textbf{Automatic date:}
 \begin{codeblock}
-\\def\\mydatefootnote\{\\currentdate}
+\\def\\mydatefootnote\{\\currentdate\}
 \end{codeblock}
       Today: \currentdate{}
     \end{column}


### PR DESCRIPTION
This PR mainly concerns the `main.tex` template. It aims to show all available options defined in the `.sty` files. Additional changes in `beamertools.sty` target the `darkmode` compatibility.

Most important changes:

- Use `\section` and `\subsection` instead of `\part`
- Show how a table of contents can be generated
- Added `fontawesome` and `emoji` tables
- Added `.gitignore` for working locally with Overleaf Git integration
- General refactoring